### PR TITLE
Fix loadland

### DIFF
--- a/src/GLand.hpp
+++ b/src/GLand.hpp
@@ -26,7 +26,7 @@ public:
 };
 class GLandFace {
 public:
-	short Index[3];
+	unsigned short Index[3];
 	GVector Vertex[3];
 	GVector Normal;
 	GVector Center;

--- a/src/Rigidmain.cpp
+++ b/src/Rigidmain.cpp
@@ -3985,7 +3985,7 @@ HRESULT LoadLand(LPDIRECT3DDEVICE8 Device, char *fname)
 	LPDIRECT3DVERTEXBUFFER8 pMeshVB;
 	LPDIRECT3DINDEXBUFFER8 pMeshIB;
 	D3DVERTEX             *pVertex;
-	struct { short p1, p2, p3; } *pIndex;
+	struct {unsigned short p1, p2, p3; } *pIndex;
 
 	for (i = 0;i < (signed int)g_pLandMesh->m_dwNumMaterials;i++) {
 		g_pLandMesh->m_pMaterials[i].Diffuse.a = 0.5;

--- a/src/Rigidmain.cpp
+++ b/src/Rigidmain.cpp
@@ -4003,7 +4003,8 @@ HRESULT LoadLand(LPDIRECT3DDEVICE8 Device, char *fname)
 	LPD3DXMESH lpMeshC;
 	g_pLandMesh->GetSysMemMesh()->Optimize(D3DXMESHOPT_ATTRSORT, NULL, NULL, NULL, NULL, &lpMeshC);
 	lpMeshC->GetAttributeTable(NULL, &(g_World->Land->AttribTableSize));
-	D3DXATTRIBUTERANGE AttribTable[100];
+	//D3DXATTRIBUTERANGE AttribTable[100];
+	D3DXATTRIBUTERANGE* AttribTable = new D3DXATTRIBUTERANGE[g_World->Land->AttribTableSize];
 	lpMeshC->GetAttributeTable(AttribTable, &(g_World->Land->AttribTableSize));
 	pMeshVB->Lock(0, 0, (BYTE**)&pVertex, D3DLOCK_READONLY);
 	landCode = 0;
@@ -4042,6 +4043,7 @@ HRESULT LoadLand(LPDIRECT3DDEVICE8 Device, char *fname)
 	}
 	pMeshIB->Unlock();
 	pMeshIB->Release();
+	delete[] AttribTable;
 	if (lpMeshC != NULL) lpMeshC->Release();
 
 	for (unsigned int j = 0;j < g_World->Land->AttribTableSize;j++) {


### PR DESCRIPTION
LoadLandについて、
・素材数が１００以上のマップが落ちる
・頂点数が2^15以上2^16未満のマップで落ちる
を修正。
2^16以上の頂点については対応が難しそう
