### PR TITLE
Fix fuel calculation bug. #12

### DIFF
--- a/src/GRigid.cpp
+++ b/src/GRigid.cpp
@@ -156,6 +156,11 @@ void GRigid::RSet()
 }
 void GRigid::CalcTotalFuel()
 {
+	if (Parent == NULL) {
+		Top->TotalFuelMax = 0;
+		Top->TotalFuel = 0;
+		Top->TotalFuel2 = 0;
+	}
 	Top->TotalFuelMax += FuelMax;
 	Top->TotalFuel += Fuel;
 	if (ChipType == GT_CHIPH) Top->TotalFuel2 += Fuel;


### PR DESCRIPTION
燃料消費が1/nになっていたバグの修正
C9よりバックポート。
検証済み(Slackにいつぞか上がってたFuelTest.rcd)。