### PR TITLE
Visual Studio 2017対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,11 @@ RigidChips
 
 ## How to build
 
-VisualStudio2013を使用してビルドを行います．
+Visual Studio 2017 (v15.5以降)を使用してビルドを行います．
 
-1. `Rigid8.slnを`開きます．すると以下のダイアログが表示されるのでOKを選択します．
-![dev01](https://github.com/rigidchips-lib/rigidchips/blob/master/doc/images/dev01.png)
+1. `Rigid8.slnを`開きます．
 
-2. プロジェクトのプロパティページの`構成プロパティ`->`全般`から，`プラットフォームツールセット`を`Visual Studio2013(v120)`に指定します．
-![dev02](https://github.com/rigidchips-lib/rigidchips/blob/master/doc/images/dev02.png)
-
-3. 次に`構成プロパティ`->`リンカ`->`詳細設定`の，`安全な例外ハンドラーを含むイメージ`を`いいえ(/SAFESEH:NO)`に指定します．
-![dev03](https://github.com/rigidchips-lib/rigidchips/blob/master/doc/images/dev03.png)
-
-4. ビルドを行います．
-
-## How to debug build
-
-デバッグビルドを行うにはHow to buildの内容に加えて以下の設定が必要です．
-
-`プロジェクトのプロパティ`->`VC++プロパティ`の`インクルードディレクトリ`と`ライブラリディレクトリ`をReleaseからDebugにコピーします．
-
+2. ビルドを行います．
 
 
 ## Contribution

--- a/Rigid8.vcxproj
+++ b/Rigid8.vcxproj
@@ -18,7 +18,7 @@
     <ProjectName>Rigid</ProjectName>
     <ProjectGuid>{82F30A2F-6679-45E1-BCF7-74D9757EE036}</ProjectGuid>
     <RootNamespace>Rigid</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -31,7 +31,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>NotSet</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Template|Win32'">
     <PlatformToolset>v140</PlatformToolset>
@@ -112,7 +112,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>dsound.lib;dinput8.lib;dxerr8.lib;d3dx8dt.lib;d3d8.lib;d3dxof.lib;dxguid.lib;winmm.lib;odbc32.lib;odbccp32.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dsound.lib;dinput8.lib;dxerr8.lib;d3dx8dt.lib;d3d8.lib;d3dxof.lib;dxguid.lib;winmm.lib;odbc32.lib;odbccp32.lib;imm32.lib;legacy_stdio_definitions.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\Release/Rigid.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <IgnoreSpecificDefaultLibraries>libci.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -159,7 +159,7 @@
       <Culture>0x0411</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>dsound.lib;dinput8.lib;dxerr8.lib;d3dx8dt.lib;d3d8.lib;imm32.lib;d3dxof.lib;dxguid.lib;winmm.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dsound.lib;dinput8.lib;dxerr8.lib;d3dx8dt.lib;d3d8.lib;imm32.lib;d3dxof.lib;dxguid.lib;winmm.lib;odbc32.lib;odbccp32.lib;legacy_stdio_definitions.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\Debug/Rigid.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>


### PR DESCRIPTION
Visual Studio 2017でビルドできるようにする変更です。普通にExpressでOKです。

ただ、Visual Studio 2017 15.5以降が必要、ターゲットがWin10になり、ツールキットが更新されます。
READMEはざっくり削りました。

何か足りないところがありそうなので確認をお願いします。